### PR TITLE
Transition's styling class get transition id instead state's name

### DIFF
--- a/src/components/WorkflowChart.vue
+++ b/src/components/WorkflowChart.vue
@@ -17,7 +17,7 @@
             :transitionPath="transition.path"
             :transitionPathRadius="transitionPathRadius"
             :label="transition.label"
-            :stylingClass="transition.stylingClass"
+            :stylingClass="transition.id"
             @click="$emit('transition-click', $event)" />
     </div>
 </template>


### PR DESCRIPTION
Transition's styling class getting transition **id** instead previos state's name. This makes finding transition's path and label into DOM more convinient.  
